### PR TITLE
added 'main' property to package.json for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "title": "Get text selection or replace selected text in input field or textarea.",
     "description": "Get text selection or replace selected text in input field or textarea.",
     "version": "0.2.1",
+    "main": "lib/field-selection.js",
     "author": {
         "name": "Oleg Slobodskoi",
         "email": "oleg008@gmail.com"


### PR DESCRIPTION
Without this, browserify won't work. Failing with:

```
Error: Cannot find module 'field-selection' from '...mypath...'
```
